### PR TITLE
Update shortcuts to speed up and down time

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 * Left click and move (on object) : Move a planet
 * Right click and move : Move the view
 * Scroll : Zoom
-* Press - : Slow down time
-* Press + : Speed up time
+* Press Down : Slow down time
+* Press Up : Speed up time
 
 # Installation
 

--- a/src/Events/Listeners/UniverseSpeed.cpp
+++ b/src/Events/Listeners/UniverseSpeed.cpp
@@ -3,11 +3,11 @@
 
 void Listener::UniverseSpeed::onEvent(const sf::Event &event, sf::View &view, sf::RenderWindow &window, Universe &universe)
 {
-  if (event.key.code == sf::Keyboard::Key::Add)
+  if (event.key.code == sf::Keyboard::Key::Up)
     {
       universe.increaseSpeed();
     }
-  else if (event.key.code == sf::Keyboard::Key::Subtract)
+  else if (event.key.code == sf::Keyboard::Key::Down)
     {
       universe.decreaseSpeed();
     }


### PR DESCRIPTION
Avoid issues (https://github.com/SFML/SFML/issues/185) with + and - only working with numpads

Some smart people without a numpad couldn't control time.
